### PR TITLE
Add Git Info to Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ bin/
 
 # Git info
 src/main/deploy/branch.txt
+src/main/deploy/commit.txt

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ bin/
 
 # IntelliJ
 .idea/
+
+# Git info
+src/main/deploy/branch.txt

--- a/build.gradle
+++ b/build.gradle
@@ -101,3 +101,28 @@ wpi.java.configureTestTasks(test)
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
 }
+
+// Setup a task to write the branch name to a file
+tasks.register("writeBranchName") {
+   // Define an output stream to write to instead of terminal
+   def stdout = new ByteArrayOutputStream()
+
+   // Execute the git command
+   exec {
+      commandLine "git", "rev-parse", "--abbrev-ref", "HEAD"
+      // Write to the output stream instead of terminal
+      standardOutput = stdout
+   }
+
+   // Parse the output into a string
+   def branch = stdout.toString().trim()
+
+   // Create a new file
+   new File(
+      // Join project directory and deploy directory
+      projectDir.toString() + "/src/main/deploy",
+      // File name to write to
+      "branch.txt"
+   ).text = branch // Set the contents of the file to the variable branch
+}
+deploy.targets.roborio.artifacts.frcStaticFileDeploy.dependsOn(writeBranchName)

--- a/build.gradle
+++ b/build.gradle
@@ -126,3 +126,21 @@ tasks.register("writeBranchName") {
    ).text = branch // Set the contents of the file to the variable branch
 }
 deploy.targets.roborio.artifacts.frcStaticFileDeploy.dependsOn(writeBranchName)
+
+// Setup a task to write the commit hash to a file
+tasks.register("writeCommitHash") {
+   def stdout = new ByteArrayOutputStream()
+
+   exec {
+     commandLine "git", "rev-parse", "HEAD"
+     standardOutput = stdout
+   }
+
+   def commitHash = stdout.toString().trim()
+
+   new File(
+      projectDir.toString() + "/src/main/deploy",
+      "commit.txt"
+   ).text = commitHash
+}
+deploy.targets.roborio.artifacts.frcStaticFileDeploy.dependsOn(writeCommitHash)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,8 +6,13 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import edu.wpi.first.wpilibj2.command.Command;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.XboxController;
-import frc.robot.subsystems.*;
 
 /**
  * This class is where the bulk of the robot should be declared. Since
@@ -45,6 +50,36 @@ public class RobotContainer {
     m_chooser.setDefaultOption("Autonomous Command", new AutonomousCommand());
 
     SmartDashboard.putData("Auto Mode", m_chooser);
+
+    displayGitInfo();
+  }
+
+  private String getFileContents(String filename) {
+    // Create the file object
+    File file = new File(Filesystem.getDeployDirectory(), filename);
+    // Open the file stream
+    try (FileInputStream inputStream = new FileInputStream(file)) {
+      // Prepare the buffer
+      byte[] data = new byte[(int) file.length()];
+      // Read the data
+      data = inputStream.readAllBytes();
+      // Format into string and return
+      return new String(data, "UTF-8");
+    } catch (IOException e) {
+      // Print exception and return
+      e.printStackTrace();
+      return "Unknown";
+    }
+  }
+
+  private void displayGitInfo() {
+    // Get the branch name and display on the dashboard
+    String branchName = getFileContents("branch.txt");
+    SmartDashboard.putString("Branch Name", branchName);
+
+    // Get the commit hash and display on the dashboard
+    String commitHash = getFileContents("commit.txt");
+    SmartDashboard.putString("Commit Hash", commitHash);
   }
 
   public static RobotContainer getInstance() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -79,7 +79,7 @@ public class RobotContainer {
 
     // Get the commit hash and display on the dashboard
     String commitHash = getFileContents("commit.txt");
-    SmartDashboard.putString("Commit Hash", commitHash);
+    SmartDashboard.putString("Commit Hash", commitHash.substring(0, 8));
   }
 
   public static RobotContainer getInstance() {


### PR DESCRIPTION
This PR follows the [WPILib docs](https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/deploy-git-data.html) to add the git branch name and commit hash to the dashboard.